### PR TITLE
Only initialise parameter type to QIcon map when it is first used.

### DIFF
--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphpanelandgraphswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationgraphpanelandgraphswidget.cpp
@@ -1127,7 +1127,7 @@ void SimulationExperimentViewInformationGraphPanelAndGraphsWidget::populateGraph
 
         // Add the current parameter to the 'current' component menu
 
-        QAction *parameterAction = componentMenu->addAction(CellMLSupport::CellmlFileRuntimeParameterIcons.value(parameter->type()),
+        QAction *parameterAction = componentMenu->addAction(CellMLSupport::CellmlFileRuntimeParameter::icon(parameter->type()),
                                                             parameter->formattedName());
 
         // Create a connection to handle the parameter value update

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationparameterswidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewinformationparameterswidget.cpp
@@ -372,7 +372,7 @@ void SimulationExperimentViewInformationParametersWidget::populateModel(CellMLSu
         property->setEditable(   (parameter->type() == CellMLSupport::CellmlFileRuntimeParameter::Constant)
                               || (parameter->type() == CellMLSupport::CellmlFileRuntimeParameter::State));
 
-        property->setIcon(CellMLSupport::CellmlFileRuntimeParameterIcons.value(parameter->type()));
+        property->setIcon(CellMLSupport::CellmlFileRuntimeParameter::icon(parameter->type()));
 
         property->setName(parameter->formattedName(), false);
         property->setUnit(parameter->formattedUnit(pRuntime->voi()->unit()), false);
@@ -478,7 +478,7 @@ void SimulationExperimentViewInformationParametersWidget::populateContextMenu(Ce
 
         // Add the current parameter to the 'current' component menu
 
-        QAction *parameterAction = componentMenu->addAction(CellMLSupport::CellmlFileRuntimeParameterIcons.value(parameter->type()),
+        QAction *parameterAction = componentMenu->addAction(CellMLSupport::CellmlFileRuntimeParameter::icon(parameter->type()),
                                                             parameter->formattedName());
 
         // Create a connection to handle the graph requirement against our

--- a/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
+++ b/src/plugins/simulation/SimulationExperimentView/src/simulationexperimentviewsimulationwidget.cpp
@@ -3072,7 +3072,7 @@ void SimulationExperimentViewSimulationWidget::simulationResultsExport()
     DataStoreInterface *dataStoreInterface = mDataStoreInterfaces.value(qobject_cast<QAction *>(sender()));
     DataStore::DataStoreData *dataStoreData = dataStoreInterface->getData(mSimulation->fileName(),
                                                                           mSimulation->results()->dataStore(),
-                                                                          CellMLSupport::CellmlFileRuntimeParameterIcons);
+                                                                          CellMLSupport::CellmlFileRuntimeParameter::icons());
 
     if (dataStoreData) {
         // We have got the data we need, so do the actual export

--- a/src/plugins/support/CellMLSupport/src/cellmlfileruntime.cpp
+++ b/src/plugins/support/CellMLSupport/src/cellmlfileruntime.cpp
@@ -61,10 +61,6 @@ namespace CellMLSupport {
 
 //==============================================================================
 
-QMap<int, QIcon> CellmlFileRuntimeParameterIcons;
-
-//==============================================================================
-
 CellmlFileRuntimeParameter::CellmlFileRuntimeParameter(const QString &pName,
                                                        int pDegree,
                                                        const QString &pUnit,
@@ -199,6 +195,44 @@ QString CellmlFileRuntimeParameter::formattedUnit(const QString &pVoiUnit) const
     }
 
     return mUnit+perVoiUnitDegree;
+}
+
+//==============================================================================
+
+QIcon CellmlFileRuntimeParameter::icon(ParameterType pParameterType)
+{
+    // Return an icon representating ourselves
+
+    return icons().value(pParameterType);
+}
+
+//==============================================================================
+
+QMap<int, QIcon> CellmlFileRuntimeParameter::icons()
+{
+    // Return the mapping between a parameter type and its corresponding icon
+
+    static QMap<int, QIcon> CellmlFileRuntimeParameterIcons = QMap<int, QIcon>();
+
+    static const QIcon VoiIcon              = QIcon(":/CellMLSupport/voi.png");
+    static const QIcon ConstantIcon         = QIcon(":/CellMLSupport/constant.png");
+    static const QIcon ComputedConstantIcon = QIcon(":/CellMLSupport/computedConstant.png");
+    static const QIcon RateIcon             = QIcon(":/CellMLSupport/rate.png");
+    static const QIcon StateIcon            = QIcon(":/CellMLSupport/state.png");
+    static const QIcon AlgebraicIcon        = QIcon(":/CellMLSupport/algebraic.png");
+
+    // Initialise the mapping the first time we are called
+
+    if (CellmlFileRuntimeParameterIcons.isEmpty()) {
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Voi, VoiIcon);
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Constant, ConstantIcon);
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::ComputedConstant, ComputedConstantIcon);
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Rate, RateIcon);
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::State, StateIcon);
+        CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Algebraic, AlgebraicIcon);
+    }
+
+    return CellmlFileRuntimeParameterIcons;
 }
 
 //==============================================================================

--- a/src/plugins/support/CellMLSupport/src/cellmlfileruntime.h
+++ b/src/plugins/support/CellMLSupport/src/cellmlfileruntime.h
@@ -102,6 +102,9 @@ public:
 
     QString formattedUnit(const QString &pVoiUnit) const;
 
+    static QIcon icon(ParameterType pParameterType);
+    static QMap<int, QIcon> icons();
+
 private:
     QString mName;
     int mDegree;
@@ -114,10 +117,6 @@ private:
 //==============================================================================
 
 typedef QList<CellmlFileRuntimeParameter *> CellmlFileRuntimeParameters;
-
-//==============================================================================
-
-extern QMap<int, QIcon> CellmlFileRuntimeParameterIcons;
 
 //==============================================================================
 

--- a/src/plugins/support/CellMLSupport/src/cellmlsupportplugin.cpp
+++ b/src/plugins/support/CellMLSupport/src/cellmlsupportplugin.cpp
@@ -62,24 +62,6 @@ CellMLSupportPlugin::CellMLSupportPlugin()
     static CellmlInterfaceData data(qobject_cast<FileTypeInterface *>(this));
 
     Core::globalInstance(CellmlInterfaceDataSignature, &data);
-
-    // Determine the mapping between a parameter type and its corresponding icon
-
-    static const QIcon VoiIcon              = QIcon(":/CellMLSupport/voi.png");
-    static const QIcon ConstantIcon         = QIcon(":/CellMLSupport/constant.png");
-    static const QIcon ComputedConstantIcon = QIcon(":/CellMLSupport/computedConstant.png");
-    static const QIcon RateIcon             = QIcon(":/CellMLSupport/rate.png");
-    static const QIcon StateIcon            = QIcon(":/CellMLSupport/state.png");
-    static const QIcon AlgebraicIcon        = QIcon(":/CellMLSupport/algebraic.png");
-
-    CellmlFileRuntimeParameterIcons = QMap<int, QIcon>();
-
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Voi, VoiIcon);
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Constant, ConstantIcon);
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::ComputedConstant, ComputedConstantIcon);
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Rate, RateIcon);
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::State, StateIcon);
-    CellmlFileRuntimeParameterIcons.insert(CellmlFileRuntimeParameter::Algebraic, AlgebraicIcon);
 }
 
 //==============================================================================


### PR DESCRIPTION
This fixes a crash at plugin load time when `CellMLSupportPlugin` initialises the parameter type icons.