### PR TITLE
Give our Python modules a filename otherwise IPython tracebacks are noisy

### DIFF
--- a/src/plugins/miscellaneous/PythonConsoleWindow/src/pythonconsolewindow.cpp
+++ b/src/plugins/miscellaneous/PythonConsoleWindow/src/pythonconsolewindow.cpp
@@ -129,6 +129,10 @@ PythonConsoleWindow::PythonConsoleWindow(QWidget *pParent) :
         return;
     }
 
+    // IPython tracebacks are noisy if modules have an empty filename, so set one
+
+    qtConsoleModule.addVariable("__file__", "QtConsole");
+
     // Create and retrive an IPython widget
 
     PyObject *createWidget = pythonQtInstance->lookupObject(qtConsoleModule, "create_ipython_widget");

--- a/src/plugins/support/PythonQtSupport/src/pythonqtsupportplugin.cpp
+++ b/src/plugins/support/PythonQtSupport/src/pythonqtsupportplugin.cpp
@@ -112,6 +112,10 @@ void PythonQtSupportPlugin::initializePlugin()
     // Create a Python module to access OpenCOR's objects
 
     mOpenCORModule = PythonQt::self()->createModuleFromScript("OpenCOR");
+
+    // IPython tracebacks are noisy if modules have an empty filename, so set one
+
+    mOpenCORModule.addVariable("__file__", "OpenCOR");
 }
 
 //==============================================================================


### PR DESCRIPTION
This should prevent the `ERROR:root:Internal Python error in the inspect module` errors when Python is trying to provide a stack traceback, as well as the `... object has no attribute '_render_traceback_'` errors in the Python console.
