### PR TITLE
Run `set_python_path` script when starting OpenCOR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1380,12 +1380,6 @@ if(WIN32)
             \\\${UnregisterExtension} \\\".cellml\\\" \\\"CellML File\\\"
             System::Call \\\"Shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)\\\"
         ")
-
-        # Update Python scripts to refer to our installed Python
-
-        set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
-            Exec '\\\"\\\$INSTDIR\\\\Python\\\\bin\\\\python.exe\\\" \\\"\\\$INSTDIR\\\\Python\\\\Scripts\\\\set_python_path.py\\\" \\\"\\\$INSTDIR\\\\Python\\\" -s'
-        ")
     endif()
 elseif(APPLE)
     # Select PackageMaker and ZIP as the packagers on macOS

--- a/distrib/linux/runpython.in
+++ b/distrib/linux/runpython.in
@@ -2,6 +2,4 @@
 
 appDir="$(cd "$(dirname "$0")"; pwd)"
 
-${appDir}/setpythonpath
-
 ${appDir}/bin/@CMAKE_PROJECT_NAME@ -c PythonShell $*

--- a/distrib/macos/runpython.in
+++ b/distrib/macos/runpython.in
@@ -2,6 +2,4 @@
 
 appDir="$(cd "$(dirname "$0")"; pwd)"
 
-${appDir}/setpythonpath
-
 ${appDir}/@CMAKE_PROJECT_NAME@.app/Contents/MacOS/@CMAKE_PROJECT_NAME@ -c PythonShell $*

--- a/distrib/windows/runpython.bat.in
+++ b/distrib/windows/runpython.bat.in
@@ -2,6 +2,4 @@
 
 SET appDir=%~dp0
 
-CALL "%appDir%setpythonpath.bat"
-
 "%appDir%bin\${CMAKE_PROJECT_NAME}" -c PythonShell %*

--- a/src/plugins/thirdParty/Python/scripts/set_python_path.py
+++ b/src/plugins/thirdParty/Python/scripts/set_python_path.py
@@ -46,7 +46,6 @@ import re
 import sys
 import logging
 import marshal
-import argparse
 from types import CodeType
 from collections import OrderedDict
 
@@ -217,15 +216,16 @@ def update_paths(base, scripts_dir, clear_args, extra_args):
     return True
 
 
-def main():
+if __name__ == '__main__':
+    import argparse
+
     parser = argparse.ArgumentParser(description='Update the path of scripts '
                                                  'to a new Python prefix')
-
     parser.add_argument('-c', '--clear-args', dest='clear_args',
                         default=False, action='store_true',
                         help='Clear all existing arguments to Python')
 
-    parser.add_argument('-u', '--update-path', dest='update_path',
+    parser.add_argument('-u', '--scripts-dir', dest='scripts_dir',
                         help='Path to scripts. Set to "auto" for autodetection')
 
     parser.add_argument('-v', '--verbose', dest='verbose',
@@ -238,14 +238,11 @@ def main():
                         help='Additional arguments to append to Python')
 
     args = parser.parse_args()
-    if not args.update_path:
-        args.update_path = 'auto'
+    if not args.scripts_dir:
+        args.scripts_dir = 'auto'
 
     if not args.verbose:
         logging.disable(logging.INFO)
 
-    sys.exit(0 if update_paths(args.path, args.update_path, args.clear_args, args.extra_args) else 1)
-
-
-if __name__ == '__main__':
-    main()
+    if not update_paths(args.path, args.scripts_dir, args.clear_args, args.extra_args):
+        sys.exit(1)

--- a/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
+++ b/src/plugins/thirdParty/PythonPackages/CMakeLists.txt
@@ -479,7 +479,7 @@ endif()
 
 add_custom_command(TARGET ${PROJECT_NAME}
                    POST_BUILD
-                   COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_SCRIPT_DIR}/set_python_path.py --update-path ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_RELATIVE_SCRIPT_DIR}
+                   COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_SCRIPT_DIR}/set_python_path.py --scripts-dir ${FULL_LOCAL_EXTERNAL_PACKAGE_DIR}/${PYTHON_RELATIVE_SCRIPT_DIR}
                                                                                                       ${PYTHON_ROOT_DIR}
                                                 -s)
 


### PR DESCRIPTION
This should resolve issue #2205.

The Python package has to be rebuilt due to changes to `set_python_path.py`.

