### PR TITLE
Python: PythonQt requires full class names for result types.

### DIFF
--- a/src/plugins/support/SimulationSupport/src/simulation.h
+++ b/src/plugins/support/SimulationSupport/src/simulation.h
@@ -430,8 +430,8 @@ public slots:
     void reload();
     void rename(const QString &pFileName);
 
-    SimulationData * data() const;
-    SimulationResults * results() const;
+    OpenCOR::SimulationSupport::SimulationData * data() const;
+    OpenCOR::SimulationSupport::SimulationResults * results() const;
 
     int runsCount() const;
     quint64 runSize(int pRun = -1) const;

--- a/src/plugins/support/SimulationSupport/src/simulationsupportpythonwrapper.h
+++ b/src/plugins/support/SimulationSupport/src/simulationsupportpythonwrapper.h
@@ -98,10 +98,10 @@ public slots:
 
     OpenCOR::DataStore::DataStoreVariable * points(OpenCOR::SimulationSupport::SimulationResults *pSimulationResults) const;
 
-    PyObject * algebraic(SimulationResults *pSimulationResults) const;
-    PyObject * constants(SimulationResults *pSimulationResults) const;
-    PyObject * states(SimulationResults *pSimulationResults) const;
-    PyObject * rates(SimulationResults *pSimulationResults) const;
+    PyObject * algebraic(OpenCOR::SimulationSupport::SimulationResults *pSimulationResults) const;
+    PyObject * constants(OpenCOR::SimulationSupport::SimulationResults *pSimulationResults) const;
+    PyObject * states(OpenCOR::SimulationSupport::SimulationResults *pSimulationResults) const;
+    PyObject * rates(OpenCOR::SimulationSupport::SimulationResults *pSimulationResults) const;
 
 private slots:
     void simulationError(const QString &pErrorMessage);


### PR DESCRIPTION
And if not, PythonQt sees the resulting objects as derived from a general C++ class and not QObject. Before:
```
>>> repr(d)
SimulationData (C++ object at: 0x7fa7c6ccac20)
```
After:
```
>>> repr(d)
SimulationSupport::SimulationData (OpenCOR::SimulationSupport::SimulationData at: 0x7fb210aea5c0)
```